### PR TITLE
Docker build & run streamlining

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,3 +23,5 @@ RUN ./build.sh
 RUN cp settings.example.json settings.json
 
 RUN chmod +x init_processes.sh
+
+ENTRYPOINT ["/bin/bash", "-c", "docker-entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,4 +20,6 @@ COPY . .
 RUN chmod +x build.sh
 RUN ./build.sh
 
+RUN cp settings.example.json settings.json
+
 RUN chmod +x init_processes.sh

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+./server_autofill.sh
+
 echo 'starting pm2...';
 
 pm2 start pm2.config.js

--- a/server_autofill.sh
+++ b/server_autofill.sh
@@ -17,7 +17,6 @@ fi
 cd config
 
 # Template to actual settings.json manipulation
-cp settings.example.json settings.json
 
 priv_key="/keys/key.txt"
 


### PR DESCRIPTION
### Checklist
- [x] My branch is up-to-date with upstream/develop branch.
- [ ] Everything works and tested for Python 3.8.0 and above.
- [ ] I ran pre-commit checks against my changes.
- [ ] I've written tests against my changes and all the current present tests are passing.

### Current behaviour
The overall build and run pipelines are a mess, both for this and [the snapshotter](https://github.com/PowerLoom/snapshotter-lite-v2). `projects.json` file being created and populated at run time is a hacky way to merge configuration sources. Similarily, the docker image does not have a default entrypoint, but does expect a very specific command in order to run at all, which is instead defined in the `docker-compose.yaml` manifest under the `command` service fields.

### New expected behaviour
This is a small PR that aims to make the docker image a little easier to work with outside of the provided `docker-compose` from [the snapshotter repo](https://github.com/PowerLoom/snapshotter-lite-v2/blob/main/docker-compose.yaml).

### Change logs
- The creation of `config/settings.json` is now in the Dockerfile instead of the `snapshotter_autofill.sh` script, which shouldn't break the overall command chain but would make it possible for someone to mount a custom `settings.json` file at runtime and is overall better practice since that settings file is simply a default that is common to all container images
- Renaming `init_processes.sh` to `docker-entrypoint.sh`, which is a standard name easier to work with from the outside
- Wrapping the execution of `snapshotter_autofill.sh` inside of the newly renamed `docker-entrypoint.sh`, again making it easier to work with the container outside of the provided `docker-compose`
- Adding an `ENTRYPOINT` to the `Dockerfile` to ensure correct default behavior