### PR TITLE
feat: implement graceful shutdown of server

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -1,24 +1,49 @@
 package main
 
 import (
+	"os"
+	"os/signal"
 	"proto-snapshot-server/config"
 	"proto-snapshot-server/pkgs/helpers"
 	"proto-snapshot-server/pkgs/service"
 	"sync"
+	"syscall"
 
 	log "github.com/sirupsen/logrus"
 )
 
 func main() {
+	// Initiate logger
 	helpers.InitLogger()
+
+	// Load the config object
 	config.LoadConfig()
 
+	// Initialize the service
 	if err := service.InitializeService(); err != nil {
-		log.Fatalf("Failed to initialize service: %v", err)
+		log.Errorf("Failed to initialize service: %v", err)
 	}
+
+	// Create a new submission server instance
+	server := service.NewMsgServerImplV2()
+
+	// Set up signal handling for graceful shutdown
+	sigs := make(chan os.Signal, 1)
+	signal.Notify(sigs, syscall.SIGINT, syscall.SIGTERM, syscall.SIGQUIT)
 
 	var wg sync.WaitGroup
 	wg.Add(1)
-	go service.StartSubmissionServer(service.NewMsgServerImplV2())
+	go func() {
+		defer wg.Done()
+		service.StartSubmissionServer(server)
+	}()
+
+	// Wait for termination signal
+	sig := <-sigs
+	log.Infof("✅ Received signal: %s. Shutting down gracefully...", sig)
+
+	// Perform cleanup
+	service.GracefulShutdownServer(server)
+
 	wg.Wait()
 }

--- a/config/settings.go
+++ b/config/settings.go
@@ -11,7 +11,7 @@ import (
 var SettingsObj *Settings
 
 type Settings struct {
-	SequencerId            string
+	SequencerID            string
 	RelayerRendezvousPoint string
 	ClientRendezvousPoint  string
 	RelayerPrivateKey      string
@@ -53,8 +53,7 @@ func LoadConfig() {
 	// Optional fields with defaults
 	config.PowerloomReportingUrl = os.Getenv("POWERLOOM_REPORTING_URL")
 	config.SignerAccountAddress = os.Getenv("SIGNER_ACCOUNT_ADDRESS")
-	config.TrustedRelayersListUrl = getEnvWithDefault("TRUSTED_RELAYERS_LIST_URL",
-		"https://raw.githubusercontent.com/PowerLoom/snapshotter-lite-local-collector/feat/trusted-relayers/relayers.json")
+	config.TrustedRelayersListUrl = getEnvWithDefault("TRUSTED_RELAYERS_LIST_URL", "https://raw.githubusercontent.com/PowerLoom/snapshotter-lite-local-collector/feat/trusted-relayers/relayers.json")
 
 	// Load private key from file or env
 	config.RelayerPrivateKey = loadPrivateKey()

--- a/go.mod
+++ b/go.mod
@@ -6,16 +6,13 @@ toolchain go1.23.1
 
 require (
 	github.com/cenkalti/backoff/v4 v4.2.0
-	github.com/ethereum/go-ethereum v1.14.7
 	github.com/google/uuid v1.6.0
 	github.com/libp2p/go-libp2p v0.32.2
 	github.com/libp2p/go-libp2p-kad-dht v0.25.2
 	github.com/multiformats/go-multiaddr v0.12.2
 	github.com/pkg/errors v0.9.1
-	github.com/rcrowley/go-metrics v0.0.0-20201227073835-cf1acfcdf475
 	github.com/sirupsen/logrus v1.9.3
 	github.com/stretchr/testify v1.9.0
-	golang.org/x/time v0.5.0
 	google.golang.org/grpc v1.67.1
 	google.golang.org/protobuf v1.34.2
 )
@@ -45,7 +42,6 @@ require (
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-multierror v1.1.1 // indirect
 	github.com/hashicorp/golang-lru v0.5.4 // indirect
-	github.com/holiman/uint256 v1.3.1 // indirect
 	github.com/huin/goupnp v1.3.0 // indirect
 	github.com/ipfs/boxo v0.10.0 // indirect
 	github.com/ipfs/go-cid v0.4.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -8,8 +8,6 @@ dmitri.shuralyov.com/service/change v0.0.0-20181023043359-a85b471d5412/go.mod h1
 dmitri.shuralyov.com/state v0.0.0-20180228185332-28bcc343414c/go.mod h1:0PRwlb0D6DFvNNtx+9ybjezNCa8XF0xaYcETyp6rHWU=
 git.apache.org/thrift.git v0.0.0-20180902110319-2566ecd5d999/go.mod h1:fPE2ZNJGynbRyZ4dJvy6G277gSllfV2HJqblrnkyeyg=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
-github.com/PowerLoom/go-ethereum v1.14.7-unsupported-tx-final h1:BbX9I3Ls7dKgZ9HfWvhyN5B2ZsGR+aRNIbCxH09n+3A=
-github.com/PowerLoom/go-ethereum v1.14.7-unsupported-tx-final/go.mod h1:ZmZcHTeyZmlgwxeJPCvDLRneKZNELdbqOY9XzZwO9Gg=
 github.com/anmitsu/go-shlex v0.0.0-20161002113705-648efa622239/go.mod h1:2FmKhYUyUczH0OGQWaF5ceTx0UBShxjsH6f8oGKYe2c=
 github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/benbjohnson/clock v1.3.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
@@ -141,8 +139,6 @@ github.com/hashicorp/go-multierror v1.1.1 h1:H5DkEtf6CXdFp0N0Em5UCwQpXMWke8IA0+l
 github.com/hashicorp/go-multierror v1.1.1/go.mod h1:iw975J/qwKPdAO1clOe2L8331t/9/fmwbPZ6JB6eMoM=
 github.com/hashicorp/golang-lru v0.5.4 h1:YDjusn29QI/Das2iO9M0BHnIbxPeyuCHsjMW+lJfyTc=
 github.com/hashicorp/golang-lru v0.5.4/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uGBxy+E8yxSoD4=
-github.com/holiman/uint256 v1.3.1 h1:JfTzmih28bittyHM8z360dCjIA9dbPIBlcTI6lmctQs=
-github.com/holiman/uint256 v1.3.1/go.mod h1:EOMSn4q6Nyt9P6efbI3bueV4e1b3dGlUCXeiRV4ng7E=
 github.com/huin/goupnp v1.3.0 h1:UvLUlWDNpoUdYzb2TCn+MuTWtcjXKSza2n6CBdQ0xXc=
 github.com/huin/goupnp v1.3.0/go.mod h1:gnGPsThkYa7bFi/KWmEysQRf48l2dvR5bxr2OFckNX8=
 github.com/ipfs/boxo v0.10.0 h1:tdDAxq8jrsbRkYoF+5Rcqyeb91hgWe2hp7iLu7ORZLY=
@@ -319,8 +315,6 @@ github.com/quic-go/webtransport-go v0.6.0 h1:CvNsKqc4W2HljHJnoT+rMmbRJybShZ0YPFD
 github.com/quic-go/webtransport-go v0.6.0/go.mod h1:9KjU4AEBqEQidGHNDkZrb8CAa1abRaosM2yGOyiikEc=
 github.com/raulk/go-watchdog v1.3.0 h1:oUmdlHxdkXRJlwfG0O9omj8ukerm8MEQavSiDTEtBsk=
 github.com/raulk/go-watchdog v1.3.0/go.mod h1:fIvOnLbF0b0ZwkB9YU4mOW9Did//4vPZtDqv66NfsMU=
-github.com/rcrowley/go-metrics v0.0.0-20201227073835-cf1acfcdf475 h1:N/ElC8H3+5XpJzTSTfLsJV/mx9Q9g7kxmchpfZyxgzM=
-github.com/rcrowley/go-metrics v0.0.0-20201227073835-cf1acfcdf475/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/rogpeppe/go-internal v1.10.0 h1:TMyTOH3F/DB16zRVcYyreMH6GnZZrwQVAoYjRBZyWFQ=
 github.com/rogpeppe/go-internal v1.10.0/go.mod h1:UQnix2H7Ngw/k4C5ijL5+65zddjncjaFoBhdsK/akog=
@@ -509,8 +503,6 @@ golang.org/x/text v0.18.0 h1:XvMDiNzPAl0jr17s6W9lcaIhGUfUORdGCNsuLmPG224=
 golang.org/x/text v0.18.0/go.mod h1:BuEKDfySbSR4drPmRPG/7iBdf8hvFMuRexcpahXilzY=
 golang.org/x/time v0.0.0-20180412165947-fbb02b2291d2/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/time v0.0.0-20181108054448-85acf8d2951c/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
-golang.org/x/time v0.5.0 h1:o7cqy6amK/52YcAKIPlM3a+Fpj35zvRj2TP+e1xFSfk=
-golang.org/x/time v0.5.0/go.mod h1:3BpzKBy/shNhVucY/MWOyx10tF3SFh9QdLuxbVysPQM=
 golang.org/x/tools v0.0.0-20180828015842-6cd1fcedba52/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20181030000716-a0a13e073c7b/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=

--- a/pkgs/service/discovery_test.go
+++ b/pkgs/service/discovery_test.go
@@ -4,16 +4,17 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"github.com/libp2p/go-libp2p"
-	"github.com/libp2p/go-libp2p/core/peer"
-	ma "github.com/multiformats/go-multiaddr"
-	log "github.com/sirupsen/logrus"
-	"github.com/stretchr/testify/assert"
 	"io"
 	"net/http"
 	"net/http/httptest"
 	"proto-snapshot-server/config"
 	"testing"
+
+	"github.com/libp2p/go-libp2p"
+	"github.com/libp2p/go-libp2p/core/peer"
+	ma "github.com/multiformats/go-multiaddr"
+	log "github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
 )
 
 type Settings struct {
@@ -83,7 +84,6 @@ func TestAddPeerConnection(t *testing.T) {
 	relayerAddr := "/ip4/104.248.63.86/tcp/5001/p2p/QmQSEao6C3SuPZ8cWiYccPqsd7LtWBTzNgXQZiAjeGTQpm"
 
 	result := AddPeerConnection(ctx, host, relayerAddr)
-
 	if !result {
 		t.Error("expected true, got false")
 	}

--- a/pkgs/service/initialization.go
+++ b/pkgs/service/initialization.go
@@ -4,21 +4,24 @@ import (
 	"fmt"
 	"proto-snapshot-server/config"
 	"sync"
-	log "github.com/sirupsen/logrus"
+
 	"github.com/libp2p/go-libp2p/core/host"
 	"github.com/libp2p/go-libp2p/core/peer"
+	log "github.com/sirupsen/logrus"
+	"google.golang.org/grpc"
 )
 
 type ServiceDependencies struct {
 	hostConn    host.Host
-	sequencerId peer.ID
+	sequencerID peer.ID
 	streamPool  *StreamPool
 	initialized bool
 	mu          sync.RWMutex
 }
 
 var (
-	deps ServiceDependencies
+	deps       ServiceDependencies
+	grpcServer *grpc.Server
 )
 
 func InitializeService() error {
@@ -39,12 +42,13 @@ func InitializeService() error {
 	if SequencerHostConn == nil {
 		return fmt.Errorf("sequencer host connection not initialized")
 	}
-	if SequencerId.String() == "" {
+
+	if SequencerID.String() == "" {
 		return fmt.Errorf("sequencer ID not initialized")
 	}
 
 	deps.hostConn = SequencerHostConn
-	deps.sequencerId = SequencerId
+	deps.sequencerID = SequencerID
 
 	// Initialize stream pool
 	if err := InitLibp2pStreamPool(config.SettingsObj.MaxStreamPoolSize); err != nil {
@@ -53,8 +57,7 @@ func InitializeService() error {
 
 	deps.streamPool = GetLibp2pStreamPool()
 	deps.initialized = true
-	
-	log.Info("Service initialization complete with sequencer ID: ", deps.sequencerId.String())
+
+	log.Info("Service initialization complete with sequencer ID: ", deps.sequencerID.String())
 	return nil
 }
-

--- a/pkgs/service/libp2p_stream_pool.go
+++ b/pkgs/service/libp2p_stream_pool.go
@@ -116,6 +116,7 @@ func (p *StreamPool) GetStream() (network.Stream, error) {
 		if err != nil {
 			return nil, fmt.Errorf("failed to create new stream: %w", err)
 		}
+
 		return stream, nil
 	}
 }

--- a/pkgs/service/msg_server.go
+++ b/pkgs/service/msg_server.go
@@ -126,13 +126,23 @@ func (s *server) writeToStream(data []byte, submissionId string, submission *pkg
 	success := false
 	defer func() {
 		if !success {
-			log.Errorf("❌ Failed defer for submission (Project: %s, Epoch: %d) with ID: %s: %v",
-				submission.Request.ProjectId, submission.Request.EpochId, submissionId, err)
+			if submission.Request.EpochId == 0 {
+				log.Errorf("❌ Failed defer for SIMULATION snapshot submission (Project: %s, Epoch: %d) with ID: %s: %v",
+					submission.Request.ProjectId, submission.Request.EpochId, submissionId, err)
+			} else {
+				log.Errorf("❌ Failed defer for snapshot submission (Project: %s, Epoch: %d) with ID: %s: %v",
+					submission.Request.ProjectId, submission.Request.EpochId, submissionId, err)
+			}
 			stream.Reset()
 			stream.Close()
 		} else {
-			log.Infof("⏰ Succesful defer for submission (Project: %s, Epoch: %d) with ID: %s",
-				submission.Request.ProjectId, submission.Request.EpochId, submissionId)
+			if submission.Request.EpochId == 0 {
+				log.Infof("⏰ Succesful defer for SIMULATION snapshot submission (Project: %s, Epoch: %d) with ID: %s",
+					submission.Request.ProjectId, submission.Request.EpochId, submissionId)
+			} else {
+				log.Infof("⏰ Succesful defer for snapshot submission (Project: %s, Epoch: %d) with ID: %s",
+					submission.Request.ProjectId, submission.Request.EpochId, submissionId)
+			}
 			// Get metrics and increment success counter
 			if metrics := s.getOrCreateEpochMetrics(submission.Request.EpochId); metrics != nil {
 				metrics.succeeded.Add(1)
@@ -157,8 +167,13 @@ func (s *server) writeToStream(data []byte, submissionId string, submission *pkg
 	}
 
 	success = true
-	log.Infof("✅ Successfully wrote to stream for submission (Project: %s, Epoch: %d) with ID: %s",
-		submission.Request.ProjectId, submission.Request.EpochId, submissionId)
+	if submission.Request.EpochId == 0 {
+		log.Infof("✅ Successfully wrote to stream for SIMULATION snapshot submission (Project: %s, Epoch: %d) with ID: %s",
+			submission.Request.ProjectId, submission.Request.EpochId, submissionId)
+	} else {
+		log.Infof("✅ Successfully wrote to stream for snapshot submission (Project: %s, Epoch: %d) with ID: %s",
+			submission.Request.ProjectId, submission.Request.EpochId, submissionId)
+	}
 	return nil
 }
 

--- a/pkgs/service/msg_server_test.go
+++ b/pkgs/service/msg_server_test.go
@@ -1,0 +1,49 @@
+package service
+
+import (
+	"os"
+	"os/signal"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func StartServer() {
+
+}
+
+func TestGracefulShutdown(t *testing.T) {
+	// Initialize the service
+	err := InitializeService()
+	assert.NoError(t, err)
+
+	// Create a channel to listen for shutdown completion
+	shutdownComplete := make(chan struct{})
+
+	// Start the server in a separate goroutine
+	go func() {
+		StartServer()
+		close(shutdownComplete)
+	}()
+
+	// Give the server some time to start
+	time.Sleep(2 * time.Second)
+
+	// Send a termination signal
+	sigs := make(chan os.Signal, 1)
+	signal.Notify(sigs, syscall.SIGINT, syscall.SIGTERM)
+	sigs <- syscall.SIGINT
+
+	// Wait for the server to shut down
+	select {
+	case <-shutdownComplete:
+		// Server shut down gracefully
+	case <-time.After(20 * time.Second):
+		t.Fatal("Server did not shut down gracefully within the timeout period")
+	}
+
+	// Verify that the server has shut down gracefully
+	assert.True(t, true, "Server shut down gracefully")
+}

--- a/pkgs/service/relay_test.go
+++ b/pkgs/service/relay_test.go
@@ -2,14 +2,15 @@ package service
 
 import (
 	"context"
-	"github.com/libp2p/go-libp2p"
-	"github.com/libp2p/go-libp2p/core/peer"
 	"io"
 	"log"
 	"net/http"
 	"net/http/httptest"
 	"proto-snapshot-server/config"
 	"testing"
+
+	"github.com/libp2p/go-libp2p"
+	"github.com/libp2p/go-libp2p/core/peer"
 )
 
 func TestConnectToSequencerP2P(t *testing.T) {
@@ -36,7 +37,7 @@ func TestConnectToSequencerP2P(t *testing.T) {
 	// Initialize the configuration settings
 	config.SettingsObj = &config.Settings{
 		TrustedRelayersListUrl: ts.URL,
-		SequencerId:            "QmdJbNsbHpFseUPKC9vLt4vMsfdxA4dyHPzsAWuzYz3Yxx",
+		SequencerID:            "QmdJbNsbHpFseUPKC9vLt4vMsfdxA4dyHPzsAWuzYz3Yxx",
 	}
 
 	host, err := libp2p.New()
@@ -50,12 +51,11 @@ func TestConnectToSequencerP2P(t *testing.T) {
 
 	// Test the function
 	result := ConnectToSequencerP2P(relayers, host)
-
 	if !result {
 		t.Error("expected true, got false")
 	}
 
 	log.Println("Connected to peer 1: ", host.Network().ConnsToPeer(peer.ID(relayers[0].ID)))
 	log.Println("Connected to peer 2: ", host.Network().ConnsToPeer(peer.ID(relayers[0].ID)))
-	log.Println("Connected to peer 3: ", host.Network().ConnsToPeer(peer.ID(config.SettingsObj.SequencerId)))
+	log.Println("Connected to peer 3: ", host.Network().ConnsToPeer(peer.ID(config.SettingsObj.SequencerID)))
 }


### PR DESCRIPTION
Fixes #29
Fixes #28 

## Solution 
- A signal handling channel named `sigs` is created to capture specific OS signals such as `SIGINT`, `SIGTERM`, and `SIGQUIT`.
- When any of these signals are received, the `GracefulShutdownServer()` function is triggered.
- This function ensures that all ongoing write operations are completed, prevents new writes from being accepted, gracefully shuts down the gRPC server, and stops the libp2p stream pool.

### Checklist
- [x] My branch is up-to-date with upstream/main branch.
- [x] Everything works and tested for major version of Python/NodeJS/Go and above.
- [x] I ran pre-commit checks against my changes.
- [x] I've written tests against my changes and all the current present tests are passing.

### Change logs

#### Added
<!-- Edit these points below to describe the new features added with this PR -->
<!-- - Feature 1 -->
<!-- - Feature 2 -->
* Implement graceful shutdown mechanism and cleanup
* Added a testcase to verify the working of graceful shutdown mechanism
* Logs to indicate whether a simulation or a regular snapshot submission was sent to the sequencer

#### Changed
<!-- Edit these points below to describe the changes made in existing functionality with this PR -->
<!-- - Change 1 -->
<!-- - Change 1 -->
* When invoking the StartSubmissionServer() function, a global instance of the gRPC server is now created. This ensures that when the GracefulShutdownServer() function is called, it can access and gracefully stop the gRPC server as well.
* Added explanatory comments above each function to clarify the purpose and functionality of each step in the code
* Dependencies upgraded
* Changed all `SequencerId` to `SequencerID` for uniformity

#### Removed
<!-- Edit these points below to describe the removed features with this PR -->
<!-- - Deprecated feature 1 -->
* Functions that weren't being used in the codebase anywhere

## Testing Instructions
- Switch to `dockerify` branch of `snapshotter-lite-v2` repo
- Run `./clean_envs.sh` to clear out any old environments
- Run `./build-dev.sh`
- Let the node run for a few minutes and press `Ctrl + C` to stop the node
- You will see both the containers have stopped
- Verify by running command `docker ps`
- Run the `./build-dev.sh` script once again
- You will see the log 
```
Local collector container is not running!
🔌 ⭕ Local collector not found or unreachable - will spawn a new local collector instance