### PR TITLE
Fix: dropped submissions and stream writes

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -14,11 +14,11 @@ import (
 )
 
 func main() {
-	// Initiate logger
-	helpers.InitLogger()
-
 	// Load the config object
 	config.LoadConfig()
+
+	// Initiate logger
+	helpers.InitLogger()
 
 	// Initialize the service
 	if err := service.InitializeService(); err != nil {

--- a/config/settings.go
+++ b/config/settings.go
@@ -29,6 +29,7 @@ type Settings struct {
 	MaxWriteRetries          int
 	MaxConcurrentWrites      int
 	MaxStreamQueueSize       int
+	WorkerPoolSize           int
 
 	// Connection management settings
 	ConnectionRefreshInterval time.Duration
@@ -67,8 +68,9 @@ func LoadConfig() {
 	config.StreamHealthCheckTimeout = time.Duration(getEnvAsInt("STREAM_HEALTH_CHECK_TIMEOUT_MS", 5000)) * time.Millisecond
 	config.StreamWriteTimeout = time.Duration(getEnvAsInt("STREAM_WRITE_TIMEOUT_MS", 5000)) * time.Millisecond
 	config.MaxWriteRetries = getEnvAsInt("MAX_WRITE_RETRIES", 5)
-	config.MaxConcurrentWrites = getEnvAsInt("MAX_CONCURRENT_WRITES", 100)
+	config.MaxConcurrentWrites = getEnvAsInt("MAX_CONCURRENT_WRITES", 250)
 	config.MaxStreamQueueSize = getEnvAsInt("MAX_STREAM_QUEUE_SIZE", 1000)
+	config.WorkerPoolSize = getEnvAsInt("WORKER_POOL_SIZE", 250)
 
 	// Add connection refresh interval setting (default 5 minutes)
 	config.ConnectionRefreshInterval = time.Duration(getEnvAsInt("CONNECTION_REFRESH_INTERVAL_SEC", 300)) * time.Second

--- a/config/settings.go
+++ b/config/settings.go
@@ -11,6 +11,7 @@ import (
 var SettingsObj *Settings
 
 type Settings struct {
+	LogLevel               string
 	SequencerID            string
 	RelayerRendezvousPoint string
 	ClientRendezvousPoint  string
@@ -71,6 +72,9 @@ func LoadConfig() {
 	config.MaxConcurrentWrites = getEnvAsInt("MAX_CONCURRENT_WRITES", 250)
 	config.MaxStreamQueueSize = getEnvAsInt("MAX_STREAM_QUEUE_SIZE", 1000)
 	config.WorkerPoolSize = getEnvAsInt("WORKER_POOL_SIZE", 250)
+
+	// Add log level setting (default "info")
+	config.LogLevel = getEnvWithDefault("LOG_LEVEL", "info")
 
 	// Add connection refresh interval setting (default 5 minutes)
 	config.ConnectionRefreshInterval = time.Duration(getEnvAsInt("CONNECTION_REFRESH_INTERVAL_SEC", 300)) * time.Second

--- a/pkgs/helpers/logger.go
+++ b/pkgs/helpers/logger.go
@@ -1,12 +1,11 @@
 package helpers
 
 import (
-	"fmt"
 	log "github.com/sirupsen/logrus"
 	"github.com/sirupsen/logrus/hooks/writer"
 	"io"
 	"os"
-	"strconv"
+	"proto-snapshot-server/config"
 )
 
 func InitLogger() {
@@ -31,18 +30,15 @@ func InitLogger() {
 			log.DebugLevel,
 		},
 	})
-	if len(os.Args) < 2 {
-		fmt.Println("Pass loglevel as an argument if you don't want default(INFO) to be set.")
-		fmt.Println("Values to be passed for logLevel: ERROR(2),INFO(4),DEBUG(5)")
-		log.SetLevel(log.DebugLevel)
-	} else {
-		logLevel, err := strconv.ParseUint(os.Args[1], 10, 32)
-		if err != nil || logLevel > 6 {
-			log.SetLevel(log.DebugLevel) //TODO: Change default level to error
-		} else {
-			//TODO: Need to come up with approach to dynamically update logLevel.
-			log.SetLevel(log.Level(logLevel))
-		}
+
+	// Set log level based on config.SettingsObj.LogLevel
+	lvl, err := log.ParseLevel(config.SettingsObj.LogLevel)
+	if err != nil {
+		log.Warnf("Invalid log level '%s' from config, defaulting to 'info'", config.SettingsObj.LogLevel)
+		lvl = log.InfoLevel
 	}
+	log.SetLevel(lvl)
+	log.Infof("Log level set to '%s'", lvl.String())
+
 	log.SetFormatter(&log.TextFormatter{FullTimestamp: true})
 }

--- a/pkgs/service/discovery.go
+++ b/pkgs/service/discovery.go
@@ -3,10 +3,12 @@ package service
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 	"proto-snapshot-server/config"
 	"sync"
+	"time"
 
 	"github.com/pkg/errors"
 
@@ -160,4 +162,25 @@ func ConfigureDHT(ctx context.Context, host host.Host) *dht.IpfsDHT {
 	wg.Wait()
 
 	return kademliaDHT
+}
+
+func ReconnectToSequencer() error {
+	log.Info("Attempting to reconnect to sequencer...")
+	// Assuming GetSequencerConnection is defined elsewhere and returns the host and sequencer ID
+	hostConn, seqId, err := GetSequencerConnection()
+	if err != nil {
+		return fmt.Errorf("failed to get sequencer connection details: %w", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	// Attempt to connect to the sequencer peer
+	if err := hostConn.Connect(ctx, peer.AddrInfo{ID: seqId}); err != nil {
+		log.Errorf("Failed to reconnect to sequencer: %v", err)
+		return err
+	}
+
+	log.Info("Successfully reconnected to sequencer")
+	return nil
 }

--- a/pkgs/service/libp2p_stream_pool.go
+++ b/pkgs/service/libp2p_stream_pool.go
@@ -204,9 +204,9 @@ func (p *StreamPool) ReleaseStream(sw *streamWithSlot, failed bool) {
 		// On success, return stream to pool
 		p.mu.Lock()
 		if len(p.streams) >= p.maxSize {
-			// Pool full, close the stream
-			sw.stream.Reset()
+			// Pool full, gracefully close the stream
 			sw.stream.Close()
+			log.Debugf("Stream gracefully closed as pool is full: %v", sw.stream.ID())
 		} else {
 			p.streams = append(p.streams, sw.stream)
 			log.Debugf("Stream returned to pool: %v (pool size: %d/%d)", sw.stream.ID(), len(p.streams), p.maxSize)

--- a/pkgs/service/msg_server.go
+++ b/pkgs/service/msg_server.go
@@ -179,7 +179,17 @@ func (s *server) writeToStream(data []byte, submissionId string, submission *pkg
 	}
 
 	// Attempt the write
+	log.WithFields(log.Fields{
+		"submissionID": submissionId,
+		"streamID":     sw.stream.ID(),
+	}).Trace("Attempting stream write")
 	n, err := sw.stream.Write(data)
+	log.WithFields(log.Fields{
+		"submissionID": submissionId,
+		"streamID":     sw.stream.ID(),
+		"bytesWritten": n,
+		"error":        err,
+	}).Trace("Stream write completed")
 	if err != nil {
 		// First cleanup stream, then release slot
 		pool.ReleaseStream(sw, true)


### PR DESCRIPTION
<!-- Please create (if there is not one yet) a issue before sending a PR -->
<!-- Add issue number (Eg: fixes #123) -->
<!-- Always provide changes in existing tests or new tests -->

Fixes #37 

### Checklist
- [x] My branch is up-to-date with upstream/main branch.
- [x] Everything works and tested for major version of Python/NodeJS/Go and above.
- [x] I ran pre-commit checks against my changes.
- [x] I've written tests against my changes and all the current present tests are passing.

### Current behaviour
The existing stream management and connection initialization logic suffered from instability, leading to an unstable stream pool and loss of in-flight requests. This was exacerbated by a lack of robust retry mechanisms during connection attempts, particularly during the initial few seconds of sequencer connection establishment.

### New expected behaviour
The system now maintains a stable stream pool, reliably handles in-flight requests, and exhibits improved resilience during connection initialization and transient network issues due to the implementation of a backoff strategy. Submissions are no longer lost due to connection instability or initial setup issues.

### Change logs

#### Changed
- Reworked the stream release mechanism to ensure a more stable and reliable stream pool, preventing premature disconnections and loss of in-flight data.
- Implemented a backoff strategy for connection attempts and stream acquisition, improving resilience against transient network issues and reducing submission failures.

#### Added
- Introduced enhanced resiliency measures during the initialization phase of sequencer connections, ensuring a more robust and stable setup from the outset.
- Improved metrics and monitoring capabilities to provide better insights into the processing pipeline, aiding in debugging and performance analysis.


## Deployment Instructions
<!-- Any specific deployment instructions to deploy your code -->
* Change the following in the env of the lite node single setup or the multi node setup to run the `experimental` build which contains these changes:

```
LOCAL_COLLECTOR_IMAGE_TAG=experimental
```